### PR TITLE
load subr-x for using string-trim

### DIFF
--- a/conventional-changelog.el
+++ b/conventional-changelog.el
@@ -33,6 +33,7 @@
 
 ;;; Code:
 
+(require 'subr-x)
 (require 'transient)
 
 (defgroup conventional-changelog nil


### PR DESCRIPTION
This fixes a following byte-compile warning.

```
conventional-changelog.el:267:1:Warning: the function ‘string-trim’ is not
    known to be defined.
```